### PR TITLE
coin page burnt coins uses formatSupply() now

### DIFF
--- a/website/src/routes/coin/[coinSymbol]/+page.svelte
+++ b/website/src/routes/coin/[coinSymbol]/+page.svelte
@@ -780,7 +780,7 @@
 										<div class="flex justify-between">
 											<span class="text-muted-foreground text-sm">Burned Coins:</span>
 											<span class="font-mono text-sm">
-												{Number(1_000_000_000 - coin.circulatingSupply).toFixed(2)}
+												{formatSupply(Number(1_000_000_000 - coin.circulatingSupply).toFixed(2))}
 											</span>
 										</div>
 									</div>


### PR DESCRIPTION
<img width="443" height="150" alt="Screenshot_20260311_201037" src="https://github.com/user-attachments/assets/92f48c7c-7507-4927-90d1-3c950b4296b0" />
