### PR TITLE
Added period lock funds with title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .github
 review.js
 .DS_Store
+env_backup

--- a/website/src/lib/components/self/AppSidebar.svelte
+++ b/website/src/lib/components/self/AppSidebar.svelte
@@ -40,7 +40,7 @@
 		Award05Icon,
 		ArrowDown01Icon,
 		UserGroupIcon,
-		Money01Icon
+		Money01Icon,
 	} from '@hugeicons/core-free-icons';
 	import { mode, setMode } from 'mode-watcher';
 	import type { HTMLAttributes } from 'svelte/elements';
@@ -70,6 +70,7 @@
 			{ title: $_('page_names.hopium'), url: '/hopium', icon: ArrowUpDownIcon },
 			{ title: $_('page_names.arcade'), url: '/arcade', icon: Joystick04Icon },
 			{ title: $_('page_names.lottery'), url: '/lottery', icon: Money01Icon },
+			{ title: $_('page_names.titles'), url: '/titles', icon: PiggyBankIcon },
 			{ title: $_('page_names.leaderboard'), url: '/leaderboard', icon: ChampionIcon },
 			{ title: $_('page_names.shop'), url: '/shop', icon: ShoppingBasket01Icon },
 			{ title: $_('page_names.achievements'), url: '/achievements', icon: Award05Icon },

--- a/website/src/lib/components/ui/locales/en.ts
+++ b/website/src/lib/components/ui/locales/en.ts
@@ -35,6 +35,7 @@ export default {
 	page_names: {
 		home: 'Home',
 		market: 'Market',
+		titles: 'Titles',
 		hopium: 'Hopium',
 		arcade: 'Arcade',
 		leaderboard: 'Leaderboard',
@@ -59,6 +60,81 @@ export default {
 		description: "Here's the market overview for today.",
 		market_overview: 'Market Overview'
 	},
+	titles: {
+	title: 'Titles',
+	description: 'Manage your titles, track earnings, and withdraw funds.',
+	seo: {
+		title: 'Titles',
+		description: 'Manage your titles, track earnings, and withdraw funds.'
+	},
+	page: {
+		title: 'Titles',
+		description: 'Create titles, track their current value, and redeem your funds whenever you want.',
+		sign_in_prompt: 'You need to sign in to access this area.'
+	},
+	stats: {
+		total_locked: 'Total locked',
+		current_value: 'Current value',
+		rewards_earned: 'Rewards earned'
+	},
+	list: {
+		empty: 'There are no active titles right now.',
+		withdrawn_header: '{{n}} withdrawn title(s)',
+		withdrawn_meta: 'Deposit of {{amount}} • {{days}} day(s) term • withdrawn {{time}} ago'
+	},
+	badge: {
+		expired: 'Expired',
+		expires: 'Expires in {{time}}',
+		withdrawn: 'Withdrawn'
+	},
+	card: {
+		deposited: 'Deposited',
+		current_value: 'Current value',
+		rewards: 'Rewards',
+		pool_share: 'Pool share',
+		gain_info: 'Gain of {{pct}}% over {{days}} day(s).',
+		claim: 'Claim',
+		early_exit: 'Early exit',
+		early_warning: 'Early exit applied: you will receive {{deposit}} and lose {{rewards}} in rewards.'
+	},
+	form: {
+		title: 'Create title',
+		description: 'Choose a name, amount, and duration to create a new title.',
+		label: 'Name',
+		label_placeholder: 'E.g. Premium Title',
+		amount: 'Amount',
+		max: 'Max',
+		balance: 'Available balance: {{balance}}',
+		duration: 'Duration: {{n}} day(s)',
+		duration_min: '1 day',
+		duration_max: '60 days',
+		creating: 'Creating...',
+		submit: 'Create title'
+	},
+	summary: {
+		fee_rate: 'Fee rate',
+		fee_rate_value: '0%',
+		pool_share: 'Estimated share',
+		early_exit: 'Early exit',
+		early_exit_value: 'Loses accrued rewards'
+	},
+	fund: {
+		title: 'Fund summary',
+		total_shares: 'Total shares',
+		active_titles: 'Active titles'
+	},
+	errors: {
+		load_failed: 'Could not load titles.',
+		invalid_input: 'Please enter a valid name and an amount greater than zero.',
+		create_failed: 'Could not create the title.',
+		withdraw_failed: 'Could not complete the withdrawal.'
+	},
+	toast: {
+		created: 'Title created successfully.',
+		withdraw_early: 'Early withdrawal completed. You received {{payout}} and lost {{forfeited}}.',
+		withdraw_full: 'Withdrawal completed. You received {{payout}} and {{rewards}} in rewards.'
+	}
+},
 	lottery: {
 	title: 'Lottery',
 	description: 'Daily draw — 90% to the winner, 10% to the bank. Win chance grows with the pool (50% at $1M).',

--- a/website/src/lib/components/ui/locales/pt.ts
+++ b/website/src/lib/components/ui/locales/pt.ts
@@ -35,6 +35,7 @@ export default {
   page_names: {
     home: "Início",
     market: "Mercado",
+    titles: "Títulos",
     hopium: "Hopium",
     arcade: "Arcade",
     leaderboard: "Placar de Líderes",
@@ -59,6 +60,81 @@ export default {
     description: "Aqui está um panorama do mercado para hoje.",
     market_overview: "Visão Geral do Mercado",
   },
+  titles: {
+	title: 'Títulos',
+	description: 'Gerencie seus títulos, acompanhe seus rendimentos e faça retiradas.',
+	seo: {
+		title: 'Títulos',
+		description: 'Gerencie seus títulos, acompanhe seus rendimentos e faça retiradas.'
+	},
+	page: {
+		title: 'Títulos',
+		description: 'Crie títulos, acompanhe o valor atual e resgate seus fundos quando quiser.',
+		sign_in_prompt: 'Você precisa entrar para acessar esta área.'
+	},
+	stats: {
+		total_locked: 'Total bloqueado',
+		current_value: 'Valor atual',
+		rewards_earned: 'Recompensas obtidas'
+	},
+	list: {
+		empty: 'Nenhum título ativo no momento.',
+		withdrawn_header: '{{n}} título(s) retirado(s)',
+		withdrawn_meta: 'Depósito de {{amount}} • prazo de {{days}} dia(s) • retirado há {{time}}'
+	},
+	badge: {
+		expired: 'Expirado',
+		expires: 'Expira em {{time}}',
+		withdrawn: 'Retirado'
+	},
+	card: {
+		deposited: 'Depositado',
+		current_value: 'Valor atual',
+		rewards: 'Recompensas',
+		pool_share: 'Participação no fundo',
+		gain_info: 'Ganho de {{pct}}% ao longo de {{days}} dia(s).',
+		claim: 'Resgatar',
+		early_exit: 'Saída antecipada',
+		early_warning: 'Saída antecipada aplicada: você receberá {{deposit}} e perderá {{rewards}} em recompensas.'
+	},
+	form: {
+		title: 'Criar título',
+		description: 'Defina um nome, valor e duração para criar um novo título.',
+		label: 'Nome',
+		label_placeholder: 'Ex.: Título Premium',
+		amount: 'Valor',
+		max: 'Máximo',
+		balance: 'Saldo disponível: {{balance}}',
+		duration: 'Duração: {{n}} dia(s)',
+		duration_min: '1 dia',
+		duration_max: '60 dias',
+		creating: 'Criando...',
+		submit: 'Criar título'
+	},
+	summary: {
+		fee_rate: 'Taxa',
+		fee_rate_value: '0%',
+		pool_share: 'Participação estimada',
+		early_exit: 'Saída antecipada',
+		early_exit_value: 'Perde recompensas acumuladas'
+	},
+	fund: {
+		title: 'Resumo do fundo',
+		total_shares: 'Total de cotas',
+		active_titles: 'Títulos ativos'
+	},
+	errors: {
+		load_failed: 'Não foi possível carregar os títulos.',
+		invalid_input: 'Preencha um nome válido e um valor maior que zero.',
+		create_failed: 'Não foi possível criar o título.',
+		withdraw_failed: 'Não foi possível realizar a retirada.'
+	},
+	toast: {
+		created: 'Título criado com sucesso.',
+		withdraw_early: 'Retirada antecipada realizada. Você recebeu {{payout}} e perdeu {{forfeited}}.',
+		withdraw_full: 'Retirada concluída. Você recebeu {{payout}} e {{rewards}} em recompensas.'
+	}
+},
   lottery: {
     title: "Loteria",
     description:

--- a/website/src/lib/server/db/schema.ts
+++ b/website/src/lib/server/db/schema.ts
@@ -747,3 +747,33 @@ export const weeklyLotteryTicket = pgTable(
 		wkTicketUserIdx: index('weekly_lottery_ticket_user_id_idx').on(table.userId)
 	})
 );
+
+export const titleFund = pgTable('title_fund', {
+	id: integer('id').primaryKey(),
+	accRewardPerShare: decimal('acc_reward_per_share', { precision: 50, scale: 30 })
+		.notNull()
+		.default('0'),
+	totalShares: decimal('total_shares', { precision: 30, scale: 8 }).notNull().default('0')
+});
+
+export const userTitle = pgTable(
+	'user_title',
+	{
+		id: serial('id').primaryKey(),
+		userId: integer('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		label: varchar('label', { length: 100 }).notNull(),
+		initialDeposit: decimal('initial_deposit', { precision: 30, scale: 8 }).notNull(),
+		shares: decimal('shares', { precision: 30, scale: 8 }).notNull(),
+		rewardDebt: decimal('reward_debt', { precision: 50, scale: 30 }).notNull().default('0'),
+		durationDays: integer('duration_days').notNull(),
+		expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+		withdrawnAt: timestamp('withdrawn_at', { withTimezone: true }),
+		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow()
+	},
+	(table) => ({
+		userIdIdx: index('user_title_user_id_idx').on(table.userId),
+		expiresAtIdx: index('user_title_expires_at_idx').on(table.expiresAt)
+	})
+);

--- a/website/src/lib/server/titles.ts
+++ b/website/src/lib/server/titles.ts
@@ -1,0 +1,39 @@
+import { db } from './db';
+import { titleFund, userTitle, user } from './db/schema';
+import { eq, sql, and, isNull, gt } from 'drizzle-orm';
+
+export const TRADE_FEE_RATE = 0.02;
+
+async function ensureFund(tx: any) {
+	await tx.insert(titleFund).values({ id: 1 }).onConflictDoNothing();
+}
+
+export async function applyFeeToFund(fee: number, tx: any) {
+	if (fee <= 0) return;
+	await ensureFund(tx);
+	await tx
+		.update(titleFund)
+		.set({
+			accRewardPerShare: sql`${titleFund.accRewardPerShare} + ${fee.toString()}::numeric / NULLIF(${titleFund.totalShares}, 0)`
+		})
+		.where(and(eq(titleFund.id, 1), gt(titleFund.totalShares, '0')));
+}
+
+export async function getFund(tx?: any) {
+	const db_ = tx ?? db;
+	const [fund] = await db_
+		.select()
+		.from(titleFund)
+		.where(eq(titleFund.id, 1))
+		.limit(1);
+	return fund ?? { id: 1, accRewardPerShare: '0', totalShares: '0' };
+}
+
+export function computePending(title: { shares: string; rewardDebt: string }, accRewardPerShare: string): number {
+	const pending = Number(title.shares) * Number(accRewardPerShare) - Number(title.rewardDebt);
+	return Math.max(0, pending);
+}
+
+export function computeCurrentValue(title: { initialDeposit: string; shares: string; rewardDebt: string }, accRewardPerShare: string): number {
+	return Number(title.initialDeposit) + computePending(title, accRewardPerShare);
+}

--- a/website/src/routes/api/coin/[coinSymbol]/trade/+server.ts
+++ b/website/src/routes/api/coin/[coinSymbol]/trade/+server.ts
@@ -8,6 +8,7 @@ import { createNotification } from '$lib/server/notification';
 import { calculate24hMetrics, executeSellTrade } from '$lib/server/amm';
 import { checkAndAwardAchievements } from '$lib/server/achievements';
 import { hasFlag } from '$lib/data/flags';
+import { applyFeeToFund, TRADE_FEE_RATE } from '$lib/server/titles';
 
 export async function POST({ params, request }) {
 	const session = await auth.api.getSession({
@@ -122,9 +123,11 @@ export async function POST({ params, request }) {
 		}
 
 		if (type === 'BUY') {
+			const fee = Math.round(amount * TRADE_FEE_RATE * 100000000) / 100000000;
+			const effectiveAmount = amount - fee;
 			// AMM BUY: amount = dollars to spend
 			const k = poolCoinAmount * poolBaseCurrencyAmount;
-			const newPoolBaseCurrency = poolBaseCurrencyAmount + amount;
+			const newPoolBaseCurrency = poolBaseCurrencyAmount + effectiveAmount;
 			const newPoolCoin = k / newPoolBaseCurrency;
 			const coinsBought = poolCoinAmount - newPoolCoin;
 
@@ -206,6 +209,7 @@ export async function POST({ params, request }) {
 					updatedAt: new Date()
 				})
 				.where(eq(coin.id, coinData.id));
+				await applyFeeToFund(fee, tx);
 
 			const priceUpdateData = {
 				currentPrice: newPrice,
@@ -313,6 +317,7 @@ export async function POST({ params, request }) {
 					updatedAt: new Date()
 				})
 				.where(eq(user.id, userId));
+				await applyFeeToFund(sellFee, tx);
 
 			const newQuantity = Number(userHolding.quantity) - amount;
 			if (newQuantity > 0.000001) {

--- a/website/src/routes/api/titles/+server.ts
+++ b/website/src/routes/api/titles/+server.ts
@@ -1,0 +1,116 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { db } from '$lib/server/db';
+import { user, userTitle, titleFund } from '$lib/server/db/schema';
+import { eq, and, isNull, desc, sql } from 'drizzle-orm';
+import { getFund, computeCurrentValue, computePending } from '$lib/server/titles';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ request }) => {
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) throw error(401, 'Not authenticated');
+
+	const userId = Number(session.user.id);
+
+	const [titles, fund] = await Promise.all([
+		db
+			.select()
+			.from(userTitle)
+			.where(eq(userTitle.userId, userId))
+			.orderBy(desc(userTitle.createdAt)),
+		getFund()
+	]);
+
+	const accRPS = fund?.accRewardPerShare ?? '0';
+	const totalFund = Number(fund?.totalShares ?? 0);
+
+	const result = titles.map((t) => ({
+		id: t.id,
+		label: t.label,
+		initialDeposit: Number(t.initialDeposit),
+		currentValue: computeCurrentValue(t, accRPS),
+		pendingRewards: computePending(t, accRPS),
+		shares: Number(t.shares),
+		durationDays: t.durationDays,
+		expiresAt: t.expiresAt,
+		withdrawnAt: t.withdrawnAt,
+		createdAt: t.createdAt,
+		expired: new Date() >= new Date(t.expiresAt),
+		withdrawn: t.withdrawnAt !== null,
+		sharePercent: totalFund > 0 ? (Number(t.shares) / totalFund) * 100 : 0
+	}));
+
+	return json({ titles: result, totalFund, accRewardPerShare: accRPS });
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) throw error(401, 'Not authenticated');
+
+	const userId = Number(session.user.id);
+	const body = await request.json();
+	const { label, amount, durationDays } = body;
+
+	if (!label || typeof label !== 'string' || label.trim().length === 0 || label.length > 100) {
+		throw error(400, 'Invalid label');
+	}
+
+	const amt = Number(amount);
+	if (!Number.isFinite(amt) || amt <= 0) throw error(400, 'Amount must be greater than 0');
+
+	const dur = parseInt(durationDays);
+	if (!Number.isInteger(dur) || dur < 1 || dur > 60) throw error(400, 'Duration must be 1–60 days');
+
+	return db.transaction(async (tx) => {
+		const [userData] = await tx
+			.select({ baseCurrencyBalance: user.baseCurrencyBalance })
+			.from(user)
+			.where(eq(user.id, userId))
+			.for('update')
+			.limit(1);
+
+		if (!userData) throw error(404, 'User not found');
+
+		const balance = Number(userData.baseCurrencyBalance);
+		const rounded = Math.round(amt * 100000000) / 100000000;
+		if (balance < rounded) throw error(400, 'Insufficient balance');
+
+		await tx.insert(titleFund).values({ id: 1 }).onConflictDoNothing();
+
+		const [fund] = await tx
+			.select()
+			.from(titleFund)
+			.where(eq(titleFund.id, 1))
+			.for('update')
+			.limit(1);
+
+		const accRPS = fund?.accRewardPerShare ?? '0';
+		const rewardDebt = (rounded * Number(accRPS)).toFixed(30);
+		const expiresAt = new Date(Date.now() + dur * 86400000);
+
+		await tx
+			.update(user)
+			.set({ baseCurrencyBalance: (balance - rounded).toFixed(8), updatedAt: new Date() })
+			.where(eq(user.id, userId));
+
+		const [inserted] = await tx
+			.insert(userTitle)
+			.values({
+				userId,
+				label: label.trim(),
+				initialDeposit: rounded.toFixed(8),
+				shares: rounded.toFixed(8),
+				rewardDebt,
+				durationDays: dur,
+				expiresAt
+			})
+			.returning();
+
+		await tx
+			.update(titleFund)
+			.set({ totalShares: sql`${titleFund.totalShares} + ${rounded.toFixed(8)}::numeric` })
+			.where(eq(titleFund.id, 1));
+
+		return json({ title: inserted }, { status: 201 });
+	});
+};

--- a/website/src/routes/api/titles/[id]/withdraw/+server.ts
+++ b/website/src/routes/api/titles/[id]/withdraw/+server.ts
@@ -1,0 +1,93 @@
+import { auth } from '$lib/auth';
+import { error, json } from '@sveltejs/kit';
+import { db } from '$lib/server/db';
+import { user, userTitle, titleFund } from '$lib/server/db/schema';
+import { eq, and, isNull, sql, gt } from 'drizzle-orm';
+import { computePending } from '$lib/server/titles';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request, params }) => {
+	const session = await auth.api.getSession({ headers: request.headers });
+	if (!session?.user) throw error(401, 'Not authenticated');
+
+	const userId = Number(session.user.id);
+	const titleId = parseInt(params.id);
+	if (isNaN(titleId)) throw error(400, 'Invalid title ID');
+
+	return db.transaction(async (tx) => {
+		const [title] = await tx
+			.select()
+			.from(userTitle)
+			.where(and(eq(userTitle.id, titleId), eq(userTitle.userId, userId)))
+			.for('update')
+			.limit(1);
+
+		if (!title) throw error(404, 'Title not found');
+		if (title.withdrawnAt !== null) throw error(400, 'Already withdrawn');
+
+		const [fund] = await tx
+			.select()
+			.from(titleFund)
+			.where(eq(titleFund.id, 1))
+			.for('update')
+			.limit(1);
+
+		const accRPS = fund?.accRewardPerShare ?? '0';
+		const pending = computePending(title, accRPS);
+		const shares = Number(title.shares);
+		const initialDeposit = Number(title.initialDeposit);
+		const now = new Date();
+		const expired = now >= new Date(title.expiresAt);
+
+		const payout = expired
+			? Math.round((initialDeposit + pending) * 100000000) / 100000000
+			: initialDeposit;
+
+		const [userData] = await tx
+			.select({ baseCurrencyBalance: user.baseCurrencyBalance })
+			.from(user)
+			.where(eq(user.id, userId))
+			.for('update')
+			.limit(1);
+
+		if (!userData) throw error(404, 'User not found');
+
+		const newBalance = Number(userData.baseCurrencyBalance) + payout;
+
+		await tx
+			.update(user)
+			.set({ baseCurrencyBalance: newBalance.toFixed(8), updatedAt: now })
+			.where(eq(user.id, userId));
+
+		await tx
+			.update(userTitle)
+			.set({ withdrawnAt: now })
+			.where(eq(userTitle.id, titleId));
+
+		const remainingShares = Number(fund?.totalShares ?? 0) - shares;
+
+		if (!expired && pending > 0 && remainingShares > 0) {
+			await tx
+				.update(titleFund)
+				.set({
+					totalShares: sql`GREATEST(0, ${titleFund.totalShares} - ${shares.toFixed(8)}::numeric)`,
+					accRewardPerShare: sql`${titleFund.accRewardPerShare} + ${pending.toString()}::numeric / NULLIF(${titleFund.totalShares} - ${shares.toFixed(8)}::numeric, 0)`
+				})
+				.where(eq(titleFund.id, 1));
+		} else {
+			await tx
+				.update(titleFund)
+				.set({
+					totalShares: sql`GREATEST(0, ${titleFund.totalShares} - ${shares.toFixed(8)}::numeric)`
+				})
+				.where(eq(titleFund.id, 1));
+		}
+
+		return json({
+			payout,
+			pendingRewards: expired ? pending : 0,
+			forfeited: expired ? 0 : pending,
+			newBalance
+		});
+	});
+};

--- a/website/src/routes/titles/+page.svelte
+++ b/website/src/routes/titles/+page.svelte
@@ -1,0 +1,406 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Separator } from '$lib/components/ui/separator';
+	import SEO from '$lib/components/self/SEO.svelte';
+	import SignInConfirmDialog from '$lib/components/self/SignInConfirmDialog.svelte';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import {
+		LockIcon,
+		Loading03Icon,
+		Tick01Icon,
+		Alert02Icon,
+		Clock01Icon
+	} from '@hugeicons/core-free-icons';
+	import { USER_DATA } from '$lib/stores/user-data';
+	import { PORTFOLIO_SUMMARY, fetchPortfolioSummary } from '$lib/stores/portfolio-data';
+	import { toast } from 'svelte-sonner';
+	import { formatValue, formatRelativeTime } from '$lib/utils';
+	import { onMount } from 'svelte';
+	import { _ } from 'svelte-i18n';
+
+	let shouldSignIn = $state(false);
+	let titles = $state<any[]>([]);
+	let totalFund = $state(0);
+	let loading = $state(true);
+	let withdrawingId = $state<number | null>(null);
+
+	let newLabel = $state('');
+	let newAmount = $state('');
+	let newDuration = $state(30);
+	let creating = $state(false);
+
+	async function loadTitles() {
+		try {
+			const res = await fetch('/api/titles');
+			if (res.ok) {
+				const d = await res.json();
+				titles = d.titles;
+				totalFund = d.totalFund;
+			}
+		} catch {
+			toast.error($_('titles.errors.load_failed'));
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function createTitle() {
+		const amt = Number(newAmount);
+		if (!newLabel.trim() || !Number.isFinite(amt) || amt <= 0) {
+			toast.error($_('titles.errors.invalid_input'));
+			return;
+		}
+		creating = true;
+		try {
+			const res = await fetch('/api/titles', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ label: newLabel.trim(), amount: amt, durationDays: newDuration })
+			});
+			const d = await res.json();
+			if (!res.ok) {
+				toast.error(d.message || $_('titles.errors.create_failed'));
+				return;
+			}
+			toast.success($_('titles.toast.created'));
+			newLabel = '';
+			newAmount = '';
+			newDuration = 30;
+			await loadTitles();
+			fetchPortfolioSummary();
+		} catch {
+			toast.error($_('titles.errors.create_failed'));
+		} finally {
+			creating = false;
+		}
+	}
+
+	async function withdraw(id: number) {
+		withdrawingId = id;
+		try {
+			const res = await fetch(`/api/titles/${id}/withdraw`, { method: 'POST' });
+			const d = await res.json();
+			if (!res.ok) {
+				toast.error(d.message || $_('titles.errors.withdraw_failed'));
+				return;
+			}
+			const msg =
+				d.forfeited > 0
+					? $_('titles.toast.withdraw_early')
+							.replace('{{payout}}', formatValue(d.payout))
+							.replace('{{forfeited}}', formatValue(d.forfeited))
+					: $_('titles.toast.withdraw_full')
+							.replace('{{payout}}', formatValue(d.payout))
+							.replace('{{rewards}}', formatValue(d.pendingRewards));
+			toast.success(msg);
+			await loadTitles();
+			fetchPortfolioSummary();
+		} catch {
+			toast.error($_('titles.errors.withdraw_failed'));
+		} finally {
+			withdrawingId = null;
+		}
+	}
+
+	onMount(() => {
+		if ($USER_DATA) loadTitles();
+		else loading = false;
+	});
+
+	let activeTitles = $derived(titles.filter((t) => !t.withdrawn));
+	let withdrawnTitles = $derived(titles.filter((t) => t.withdrawn));
+	let balance = $derived($PORTFOLIO_SUMMARY?.baseCurrencyBalance ?? 0);
+	let totalLocked = $derived(activeTitles.reduce((s, t) => s + t.initialDeposit, 0));
+	let totalCurrentValue = $derived(activeTitles.reduce((s, t) => s + t.currentValue, 0));
+	let totalRewards = $derived(totalCurrentValue - totalLocked);
+	let projectedShare = $derived(
+		totalFund > 0 && Number(newAmount) > 0
+			? ((Number(newAmount) / (totalFund + Number(newAmount))) * 100).toFixed(2)
+			: '100.00'
+	);
+</script>
+
+<SEO
+	title="{$_('titles.seo.title')} - XprismPlay"
+	description={$_('titles.seo.description')}
+/>
+
+<SignInConfirmDialog bind:open={shouldSignIn} />
+
+<div class="container mx-auto max-w-5xl p-6">
+	<header class="mb-8">
+		<h1 class="flex items-center gap-2 text-3xl font-bold">
+			<HugeiconsIcon icon={LockIcon} class="h-7 w-7 text-yellow-500" />
+			{$_('titles.page.title')}
+		</h1>
+		<p class="text-muted-foreground mt-1">{$_('titles.page.description')}</p>
+	</header>
+
+	{#if !$USER_DATA}
+		<div class="flex h-60 flex-col items-center justify-center gap-4 text-center">
+			<HugeiconsIcon icon={LockIcon} class="text-muted-foreground/40 h-16 w-16" />
+			<p class="text-muted-foreground">{$_('titles.page.sign_in_prompt')}</p>
+			<Button onclick={() => (shouldSignIn = true)}>{$_('sign_in.sign_in')}</Button>
+		</div>
+	{:else}
+		<div class="grid gap-6 lg:grid-cols-3">
+			<div class="space-y-4 lg:col-span-2">
+				<div class="grid grid-cols-3 gap-3">
+					<Card.Root class="py-0">
+						<Card.Content class="p-4">
+							<p class="text-muted-foreground text-xs">{$_('titles.stats.total_locked')}</p>
+							<p class="mt-1 text-xl font-bold">{formatValue(totalLocked)}</p>
+						</Card.Content>
+					</Card.Root>
+					<Card.Root class="py-0">
+						<Card.Content class="p-4">
+							<p class="text-muted-foreground text-xs">{$_('titles.stats.current_value')}</p>
+							<p class="mt-1 text-xl font-bold text-green-500">{formatValue(totalCurrentValue)}</p>
+						</Card.Content>
+					</Card.Root>
+					<Card.Root class="py-0">
+						<Card.Content class="p-4">
+							<p class="text-muted-foreground text-xs">{$_('titles.stats.rewards_earned')}</p>
+							<p class="mt-1 text-xl font-bold text-yellow-500">+{formatValue(totalRewards)}</p>
+						</Card.Content>
+					</Card.Root>
+				</div>
+
+				{#if loading}
+					<div class="space-y-3">
+						{#each Array(2) as _}
+							<div class="bg-muted h-24 animate-pulse rounded-xl"></div>
+						{/each}
+					</div>
+				{:else if activeTitles.length === 0}
+					<Card.Root>
+						<Card.Content class="py-12 text-center">
+							<HugeiconsIcon icon={LockIcon} class="text-muted-foreground/40 mx-auto mb-3 h-10 w-10" />
+							<p class="text-muted-foreground">{$_('titles.list.empty')}</p>
+						</Card.Content>
+					</Card.Root>
+				{:else}
+					{#each activeTitles as title}
+						{@const gainPct =
+							title.initialDeposit > 0
+								? ((title.currentValue - title.initialDeposit) / title.initialDeposit) * 100
+								: 0}
+						<Card.Root class="overflow-hidden">
+							<Card.Content class="p-5">
+								<div class="flex items-start justify-between gap-4">
+									<div class="min-w-0 flex-1">
+										<div class="mb-2 flex flex-wrap items-center gap-2">
+											<h3 class="font-semibold">{title.label}</h3>
+											{#if title.expired}
+												<Badge variant="success" class="text-xs">
+													{$_('titles.badge.expired')}
+												</Badge>
+											{:else}
+												<Badge variant="outline" class="text-xs">
+													<HugeiconsIcon icon={Clock01Icon} class="mr-1 h-3 w-3" />
+													{$_('titles.badge.expires').replace('{{time}}', formatRelativeTime(title.expiresAt))}
+												</Badge>
+											{/if}
+										</div>
+										<div class="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
+											<div>
+												<p class="text-muted-foreground text-xs">{$_('titles.card.deposited')}</p>
+												<p class="font-mono font-medium">{formatValue(title.initialDeposit)}</p>
+											</div>
+											<div>
+												<p class="text-muted-foreground text-xs">{$_('titles.card.current_value')}</p>
+												<p class="font-mono font-medium text-green-500">{formatValue(title.currentValue)}</p>
+											</div>
+											<div>
+												<p class="text-muted-foreground text-xs">{$_('titles.card.rewards')}</p>
+												<p class="font-mono font-medium text-yellow-500">+{formatValue(title.pendingRewards)}</p>
+											</div>
+											<div>
+												<p class="text-muted-foreground text-xs">{$_('titles.card.pool_share')}</p>
+												<p class="font-mono font-medium">{title.sharePercent.toFixed(2)}%</p>
+											</div>
+										</div>
+										{#if gainPct > 0}
+											<p class="text-muted-foreground mt-2 text-xs">
+												{$_('titles.card.gain_info')
+													.replace('{{pct}}', gainPct.toFixed(4))
+													.replace('{{days}}', String(title.durationDays))}
+											</p>
+										{/if}
+									</div>
+									<div class="flex-shrink-0">
+										<Button
+											size="sm"
+											variant={title.expired ? 'default' : 'outline'}
+											onclick={() => withdraw(title.id)}
+											disabled={withdrawingId === title.id}
+										>
+											{#if withdrawingId === title.id}
+												<HugeiconsIcon icon={Loading03Icon} class="h-3 w-3 animate-spin" />
+											{:else if title.expired}
+												<HugeiconsIcon icon={Tick01Icon} class="h-3 w-3" />
+												{$_('titles.card.claim')}
+											{:else}
+												<HugeiconsIcon icon={Alert02Icon} class="h-3 w-3" />
+												{$_('titles.card.early_exit')}
+											{/if}
+										</Button>
+									</div>
+								</div>
+								{#if !title.expired}
+									<div class="mt-3 flex items-start gap-1.5 rounded-md bg-yellow-500/10 px-3 py-2">
+										<HugeiconsIcon
+											icon={Alert02Icon}
+											class="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-yellow-600"
+										/>
+										<p class="text-xs text-yellow-700 dark:text-yellow-400">
+											{$_('titles.card.early_warning')
+												.replace('{{deposit}}', formatValue(title.initialDeposit))
+												.replace('{{rewards}}', formatValue(title.pendingRewards))}
+										</p>
+									</div>
+								{/if}
+							</Card.Content>
+						</Card.Root>
+					{/each}
+				{/if}
+
+				{#if withdrawnTitles.length > 0}
+					<div>
+						<Separator class="my-4" />
+						<p class="text-muted-foreground mb-3 text-sm">
+							{$_('titles.list.withdrawn_header').replace('{{n}}', String(withdrawnTitles.length))}
+						</p>
+						<div class="space-y-2">
+							{#each withdrawnTitles as title}
+								<div
+									class="bg-muted/30 flex items-center justify-between rounded-lg border px-4 py-3 opacity-60"
+								>
+									<div>
+										<p class="text-sm font-medium">{title.label}</p>
+										<p class="text-muted-foreground text-xs">
+											{$_('titles.list.withdrawn_meta')
+												.replace('{{amount}}', formatValue(title.initialDeposit))
+												.replace('{{days}}', String(title.durationDays))
+												.replace('{{time}}', formatRelativeTime(title.withdrawnAt))}
+										</p>
+									</div>
+									<Badge variant="secondary" class="text-xs">{$_('titles.badge.withdrawn')}</Badge>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			</div>
+
+			<div>
+				<Card.Root>
+					<Card.Header>
+						<Card.Title class="text-base">{$_('titles.form.title')}</Card.Title>
+						<Card.Description>{$_('titles.form.description')}</Card.Description>
+					</Card.Header>
+					<Card.Content class="space-y-4">
+						<div class="space-y-1">
+							<Label class="text-sm">{$_('titles.form.label')}</Label>
+							<Input
+								bind:value={newLabel}
+								placeholder={$_('titles.form.label_placeholder')}
+								maxlength={100}
+							/>
+						</div>
+
+						<div class="space-y-1">
+							<div class="flex items-center justify-between">
+								<Label class="text-sm">{$_('titles.form.amount')}</Label>
+								<button
+									type="button"
+									class="text-primary hover:text-primary/80 text-xs font-medium transition-colors"
+									onclick={() => (newAmount = String(balance))}
+								>
+									{$_('titles.form.max')}
+								</button>
+							</div>
+							<Input
+								type="number"
+								bind:value={newAmount}
+								placeholder="0.00"
+								min="0.01"
+								step="0.01"
+							/>
+							<p class="text-muted-foreground text-xs">
+								{$_('titles.form.balance').replace('{{balance}}', formatValue(balance))}
+							</p>
+						</div>
+
+						<div class="space-y-1">
+							<Label class="text-sm">
+								{$_('titles.form.duration').replace('{{n}}', String(newDuration))}
+							</Label>
+							<input
+								type="range"
+								bind:value={newDuration}
+								min="1"
+								max="60"
+								step="1"
+								class="w-full accent-primary"
+							/>
+							<div class="flex justify-between text-xs text-muted-foreground">
+								<span>{$_('titles.form.duration_min')}</span>
+								<span>{$_('titles.form.duration_max')}</span>
+							</div>
+						</div>
+
+						<div class="space-y-1 rounded-lg border bg-muted/30 p-3 text-xs">
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">{$_('titles.summary.fee_rate')}</span>
+								<span class="font-mono">{$_('titles.summary.fee_rate_value')}</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">{$_('titles.summary.pool_share')}</span>
+								<span class="font-mono">{projectedShare}%</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">{$_('titles.summary.early_exit')}</span>
+								<span class="font-mono text-red-500">{$_('titles.summary.early_exit_value')}</span>
+							</div>
+						</div>
+
+						<Button
+							class="w-full"
+							onclick={createTitle}
+							disabled={creating || !newLabel.trim() || !newAmount || Number(newAmount) <= 0}
+						>
+							{#if creating}
+								<HugeiconsIcon icon={Loading03Icon} class="h-4 w-4 animate-spin" />
+								{$_('titles.form.creating')}
+							{:else}
+								<HugeiconsIcon icon={LockIcon} class="h-4 w-4" />
+								{$_('titles.form.submit')}
+							{/if}
+						</Button>
+					</Card.Content>
+				</Card.Root>
+
+				<Card.Root class="mt-4">
+					<Card.Header class="pb-2">
+						<Card.Title class="text-sm">{$_('titles.fund.title')}</Card.Title>
+					</Card.Header>
+					<Card.Content class="space-y-2 text-sm">
+						<div class="flex justify-between">
+							<span class="text-muted-foreground">{$_('titles.fund.total_shares')}</span>
+							<span class="font-mono">{formatValue(totalFund)}</span>
+						</div>
+						<div class="flex justify-between">
+							<span class="text-muted-foreground">{$_('titles.fund.active_titles')}</span>
+							<span class="font-mono">{activeTitles.length}</span>
+						</div>
+					</Card.Content>
+				</Card.Root>
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
**Add Period Fund Lock with 2% Sitewide Trade Fee**

This PR introduces a **Period Fund Lock** system, allowing users to create locked funds for a set duration. During the lock period, the deposited amount is committed until it expires or is withdrawn according to the fund rules.

It also adds a **2% fee on all trades across the site**, helping support the fund system and overall platform economy. The fee is applied automatically during trade operations, with the resulting amount reflected in the final transaction values.

### What changed

* Added period-based fund locking functionality
* Added lock duration handling
* Added fund withdrawal logic
* Applied a **2% fee to every trade** on the site
* Updated related UI and calculations to reflect the new system

### Notes

* Locked funds remain unavailable until the lock period ends ( or you can just discart the reward )
* Trade fee is applied consistently across all supported trade actions
* Existing balances and reward calculations were updated to account for the new fee structure

# EVERYTHING IS TRANSLATED 
<img width="1246" height="829" alt="image" src="https://github.com/user-attachments/assets/dcfa6d42-12d7-4331-8f62-e04bd7d3ab99" />
